### PR TITLE
Fix payments schema

### DIFF
--- a/v2.00/Payment.xsd
+++ b/v2.00/Payment.xsd
@@ -16,7 +16,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="ValidationErrors" type="ArrayOfValidationError" />
       <xs:element minOccurs="0" maxOccurs="1" name="Warnings" type="ArrayOfWarning" />
 
-      <xs:element minOccurs="1" maxOccurs="1" name="PaymentID" type="uniqueIdentifier" />
+      <xs:element minOccurs="0" maxOccurs="1" name="PaymentID" type="uniqueIdentifier" />
       <xs:element minOccurs="1" maxOccurs="1" name="Date" type="xs:dateTime" />
       <xs:element minOccurs="1" maxOccurs="1" name="Amount" type="xs:decimal" />
       <xs:element minOccurs="0" maxOccurs="1" name="Account" type="Account" />


### PR DESCRIPTION
Payment.xsd didn't declare a root element, and always required the `<PaymentID>` element.

I've added root elements for Payment (GET) and Payments (PUT), and made the `<PaymentID>` optional (since it can't exist in a PUT).

A better solution might well be to define a separate complex type for PUT and composite that into the GET one.
