### PR TITLE
Add missing include

### DIFF
--- a/v2.00/Journal.xsd
+++ b/v2.00/Journal.xsd
@@ -4,6 +4,7 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
 >
   <xs:include schemaLocation="BaseTypes.xsd" />
+  <xs:include schemaLocation="Tracking.xsd" />
   
   <xs:element name="Journals" nillable="true" type="ArrayOfJournal" />
 


### PR DESCRIPTION
This include is needed to successfully validate the TrackingCategories property on the JournalLine element.
