### PR TITLE
Fix errors thrown when generating Java classes

### DIFF
--- a/v2.00/Account.xsd
+++ b/v2.00/Account.xsd
@@ -35,7 +35,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="ReportingCode" type="reportCode" />
       <xs:element minOccurs="0" maxOccurs="1" name="ReportingCodeName" type="reportCodeName" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:simpleType name="reportCode">

--- a/v2.00/Address.xsd
+++ b/v2.00/Address.xsd
@@ -22,7 +22,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="AttentionTo" type="addressAttentionToType" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
   <xs:complexType name="ArrayOfAddress">

--- a/v2.00/Allocation.xsd
+++ b/v2.00/Allocation.xsd
@@ -22,7 +22,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="UpdatedDateUTC" nillable="true" type="xs:dateTime" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="ArrayOfAllocation">

--- a/v2.00/ApiException.xsd
+++ b/v2.00/ApiException.xsd
@@ -6,7 +6,7 @@
 
   <xs:complexType name="Elements">
     <xs:all>
-      <xs:element name="DataContractBase" maxOccurs="unbounded" minOccurs="0"/>
+      <xs:element name="DataContractBase" maxOccurs="1" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
 
@@ -17,7 +17,7 @@
         <xs:element name="ErrorNumber" type="xs:integer" minOccurs="1" maxOccurs="1" />
         <xs:element name="Type" type="xs:string" minOccurs="1" maxOccurs="1" />
         <xs:element name="Message" type="xs:string" minOccurs="1" maxOccurs="1" />
-        <xs:element name="Elements" type="Elements" maxOccurs="unbounded" minOccurs="0"/>
+        <xs:element name="Elements" type="Elements" maxOccurs="1" minOccurs="0"/>
       </xs:all>
     </xs:complexType>
   </xs:element>

--- a/v2.00/Attachment.xsd
+++ b/v2.00/Attachment.xsd
@@ -27,7 +27,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="ContentLength" type="xs:integer" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/BankTransaction.xsd
+++ b/v2.00/BankTransaction.xsd
@@ -41,7 +41,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="CurrencyRate" type="currencyRate" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/BankTransfer.xsd
+++ b/v2.00/BankTransfer.xsd
@@ -31,7 +31,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="CurrencyRate" type="currencyRate" />
       <xs:element minOccurs="0" maxOccurs="1" name="HasAttachments" type="xs:boolean" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="BankAccount">

--- a/v2.00/BrandingTheme.xsd
+++ b/v2.00/BrandingTheme.xsd
@@ -25,7 +25,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="SortOrder" type="xs:integer" />
       <xs:element minOccurs="0" maxOccurs="1" name="CreatedDateUTC" type="xs:dateTime" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Contact.xsd
+++ b/v2.00/Contact.xsd
@@ -47,7 +47,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="ContactPersons" nillable="false" type="ArrayOfContactPerson" />
       <xs:element minOccurs="0" maxOccurs="1" name="HasAttachments" nillable="false" type="xs:boolean" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:simpleType name="contactNumber">
@@ -86,8 +86,8 @@
 
   <xs:complexType name="Balances">
     <xs:all>
-      <xs:element minOccurs="0" maxOccurs="unbounded" name="AccountsReceivable" nillable="true" type="AccountsReceivable" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" name="AccountsPayable" nillable="true" type="AccountsPayable" />
+      <xs:element minOccurs="0" maxOccurs="1" name="AccountsReceivable" nillable="true" type="AccountsReceivable" />
+      <xs:element minOccurs="0" maxOccurs="1" name="AccountsPayable" nillable="true" type="AccountsPayable" />
     </xs:all>
   </xs:complexType>
 

--- a/v2.00/CreditNote.xsd
+++ b/v2.00/CreditNote.xsd
@@ -43,7 +43,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="CurrencyRate" type="currencyRate" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Currency.xsd
+++ b/v2.00/Currency.xsd
@@ -23,7 +23,7 @@
       <xs:element minOccurs="1" maxOccurs="1" name="Description" type="xs:string" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
 </xs:schema>

--- a/v2.00/Employee.xsd
+++ b/v2.00/Employee.xsd
@@ -34,7 +34,7 @@
       <xs:element name="UpdatedDateUTC" minOccurs="0" maxOccurs="1" type="xs:dateTime" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/ExpenseClaim.xsd
+++ b/v2.00/ExpenseClaim.xsd
@@ -35,7 +35,7 @@
       <xs:element name="Total" minOccurs="0" maxOccurs="1" type="itemPrice" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Invoice.xsd
+++ b/v2.00/Invoice.xsd
@@ -64,7 +64,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="HasAttachments" type="xs:boolean" />
       <xs:element minOccurs="0" maxOccurs="1" name="Attachments" type="ArrayOfAttachment" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Items.xsd
+++ b/v2.00/Items.xsd
@@ -27,7 +27,7 @@
       <xs:element name="PurchaseDetails" type="ItemPriceDetails" minOccurs="1" maxOccurs="1" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="ItemPriceDetails">
@@ -40,7 +40,7 @@
       <xs:element name="AccountCode" type="accountCode" minOccurs="0" maxOccurs="1" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Journal.xsd
+++ b/v2.00/Journal.xsd
@@ -30,7 +30,7 @@
       <xs:element minOccurs="1" maxOccurs="1" name="JournalLines" type="ArrayOfJournalLine" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <!-- Journal Lines -->
@@ -60,7 +60,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="TaxName" type="xs:string" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/LineItem.xsd
+++ b/v2.00/LineItem.xsd
@@ -31,7 +31,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="DiscountRate" type="itemPrice" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />    
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />    
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/ManualJournal.xsd
+++ b/v2.00/ManualJournal.xsd
@@ -32,7 +32,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="ExternalLinkProviderName" type="xs:string" />
       <xs:element minOccurs="0" maxOccurs="1" name="ShowOnCashBasisReports" type="xs:boolean" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <!--
@@ -57,7 +57,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="AccountCode" type="accountCode" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/Organisation.xsd
+++ b/v2.00/Organisation.xsd
@@ -51,7 +51,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="Phones" type="ArrayOfPhone" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:simpleType name="organisationName">

--- a/v2.00/Payment.xsd
+++ b/v2.00/Payment.xsd
@@ -28,7 +28,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="UpdatedDateUTC" nillable="true" type="xs:dateTime" />
       
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="ArrayOfPayment">

--- a/v2.00/Phone.xsd
+++ b/v2.00/Phone.xsd
@@ -16,7 +16,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="PhoneCountryCode" type="phoneCountryCodeType" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="ArrayOfPhone">

--- a/v2.00/Receipt.xsd
+++ b/v2.00/Receipt.xsd
@@ -51,7 +51,7 @@
       <xs:element name="Attachments" minOccurs="0" maxOccurs="1" type="ArrayOfAttachment" />
 
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>

--- a/v2.00/RepeatingInvoice.xsd
+++ b/v2.00/RepeatingInvoice.xsd
@@ -39,7 +39,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="TotalDiscount" nillable="true" type="itemPrice" />
       <xs:element minOccurs="0" maxOccurs="1" name="HasAttachments" type="xs:boolean" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="Schedule">

--- a/v2.00/Setting.xsd
+++ b/v2.00/Setting.xsd
@@ -16,7 +16,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="TrackingCategories" type="TrackingCategories" />
       <xs:element minOccurs="0" maxOccurs="1" name="DaysInPayrollYear" type="xs:string" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
 

--- a/v2.00/TaxRate.xsd
+++ b/v2.00/TaxRate.xsd
@@ -30,7 +30,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="Status" type="taxRateStatus" />
     
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
 </xs:schema>

--- a/v2.00/Tracking.xsd
+++ b/v2.00/Tracking.xsd
@@ -20,7 +20,7 @@
       <xs:element minOccurs="0" maxOccurs="1" name="Option" type="xs:string" />
     
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="TrackingCategoryOption">
@@ -28,7 +28,7 @@
       <xs:element minOccurs="1" maxOccurs="1" name="TrackingOptionID" type="uniqueIdentifier" />
       <xs:element minOccurs="1" maxOccurs="1" name="Name" type="xs:string" />
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="ArrayOfTrackingCategoryOption">

--- a/v2.00/User.xsd
+++ b/v2.00/User.xsd
@@ -32,7 +32,7 @@
       <xs:element name="OrganisationRole" minOccurs="0" maxOccurs="1" type="organisationRole" />
     
     </xs:all>
-    <xs:attribute name="status" type="entityValidationStatus" use="optional" />
+    <xs:attribute name="validationstatus" type="entityValidationStatus" use="optional" />
   </xs:complexType>
   
 </xs:schema>


### PR DESCRIPTION
Error was thrown when using JAXB to generate classes in Eclipse.
Duplicate status elements.  Renamed one to validationstatus.   Also
correct unbound maxoccurs in Contact and ApiException elements.