### PR TITLE
Changed Balances to be a xs:sequence

### DIFF
--- a/v2.00/Contact.xsd
+++ b/v2.00/Contact.xsd
@@ -85,10 +85,10 @@
   </xs:complexType>
 
   <xs:complexType name="Balances">
-    <xs:all>
+    <xs:sequence>
       <xs:element minOccurs="0" maxOccurs="unbounded" name="AccountsReceivable" nillable="true" type="AccountsReceivable" />
       <xs:element minOccurs="0" maxOccurs="unbounded" name="AccountsPayable" nillable="true" type="AccountsPayable" />
-    </xs:all>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="AccountsReceivable">


### PR DESCRIPTION
In XSD 1.0, an xs:all cannot repeat, nor any particle under xs:all, nor can it be nested under any other compositor.