### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: java
 addons:
   apt:
     packages:


### PR DESCRIPTION
The travis build defaults to ruby as the language, which is currently looking for a non existent Rakefile. 

The easiest way to avoid this is to set an appropriate language. In this case java is the most appropriate as there exists a web.xml.

Travis build green on my my fork with this change.