### PR TITLE
Add IsNonRecoverable field to TaxComponent

### DIFF
--- a/src/main/resources/XeroSchemas/v2.00/TaxRate.xsd
+++ b/src/main/resources/XeroSchemas/v2.00/TaxRate.xsd
@@ -44,6 +44,7 @@
       <xs:element minOccurs="1" maxOccurs="1" name="Name" type="xs:string" />
       <xs:element minOccurs="1" maxOccurs="1" name="Rate" type="xs:string" />
 	    <xs:element minOccurs="1" maxOccurs="1" name="IsCompound" type="xs:boolean" />
+      <xs:element monOccurs="1" maxOccurs="1" name="InNonRecoverable" type="xs:boolean" />
      </xs:all>
   </xs:complexType>
 


### PR DESCRIPTION
Add support for non-recoverable tax components that have recently been added to the API: https://developer.xero.com/documentation/api/tax-rates